### PR TITLE
Various fixes

### DIFF
--- a/brighton/brightonMixerMenu.c
+++ b/brighton/brightonMixerMenu.c
@@ -1179,6 +1179,7 @@ removeInterface(guiSynth *synth)
 	return(NULL);
 }
 
+#if 0
 brightonEvent event;
 
 int
@@ -1190,4 +1191,10 @@ doAlarm()
 /*	brightonSendEvent((void *) theSynth->win, 2, DISPLAY1 - 1, &event); */
 	return(0);
 }
-
+#else
+int
+doAlarm()
+{
+	return(0);
+}
+#endif

--- a/bristol/aksdco.c
+++ b/bristol/aksdco.c
@@ -38,7 +38,7 @@
 #include "bristol.h"
 #include "aksdco.h"
 
-static float note_diff, *zbuf;
+GLOBAL_STATE static float note_diff, *zbuf;
 
 #define BRISTOL_SQR 4
 #define SINE_LIM 0.05f

--- a/bristol/aksenv.c
+++ b/bristol/aksenv.c
@@ -46,7 +46,7 @@
 
 #define AKSENV_OUT_IND 0
 
-static float rate;
+GLOBAL_STATE static float rate;
 
 /*
  * Reset any local memory information.

--- a/bristol/arpdco.c
+++ b/bristol/arpdco.c
@@ -39,7 +39,7 @@
 #include "bristolblo.h"
 #include "arpdco.h"
 
-float note_diff, *zbuf;
+GLOBAL_STATE static float note_diff, *zbuf;
 
 #define BRISTOL_SQR 4
 
@@ -70,7 +70,7 @@ static void fillWave();
  * We should not be doing this however I need a quick resolution to some issues
  * with sync of square waves and this is a scratch buffer for the edge detector
  */
-static float *sbuf = NULL;
+GLOBAL_STATE static float *sbuf = NULL;
 
 /*
  * Reset any local memory information.

--- a/bristol/arpeggiator.c
+++ b/bristol/arpeggiator.c
@@ -25,7 +25,7 @@
 #include "bristol.h"
 #include "bristolarpeggiation.h"
 
-extern bristolMidiHandler bristolMidiRoutines;
+GLOBAL_STATE extern bristolMidiHandler bristolMidiRoutines;
 
 /* This is required for 2602222, voices left hanging when terminating */
 static void desequence(audioMain *am, Baudio *ba)

--- a/bristol/audioEngine.c
+++ b/bristol/audioEngine.c
@@ -29,7 +29,7 @@
 
 #include "dco.h"
 
-extern tableEntry defaultTable[];
+GLOBAL_STATE extern tableEntry defaultTable[];
 extern void freeBristolAudio();
 static void a440();
 
@@ -40,7 +40,7 @@ extern void rbMidiNote(audioMain *, bristolMidiMsg *);
 /*
  * Used by the a440 sine generator.
  */
-int s440holder = 0;
+GLOBAL_STATE int s440holder = 0;
 
 static void
 bristolUnlinkVoice(audioMain *audiomain, bristolVoice *v)

--- a/bristol/audiothread.c
+++ b/bristol/audiothread.c
@@ -42,8 +42,8 @@ extern int bristolJackInterface();
 
 /*int atStatus = 0; */
 
-extern int dupfd;
-extern char *outputfile;
+GLOBAL_STATE extern int dupfd;
+GLOBAL_STATE extern char *outputfile;
 extern int buildCurrentTable(Baudio *, float);
 extern void initMicrotonalTable(fTab []);
 

--- a/bristol/bit1osc.c
+++ b/bristol/bit1osc.c
@@ -46,8 +46,8 @@
 #include "bristolblo.h"
 #include "bit1osc.h"
 
-static float note_diff;
-int samplecount;
+GLOBAL_STATE static float note_diff;
+GLOBAL_STATE static int samplecount;
 
 static void fillWave(float *, int, int);
 static void buildBitoneSound(bristolOP *, bristolOPParams *);
@@ -67,7 +67,7 @@ static void buildBitoneSound(bristolOP *, bristolOPParams *);
  *
  * We have 16, 8, 4, 2, 1
  */
-static float sweeps[16] = {2, 4, 8, 16, 1, 32, 12, 20, 24, 32, 0,0,0,0,0,0};
+static const float sweeps[16] = {2, 4, 8, 16, 1, 32, 12, 20, 24, 32, 0,0,0,0,0,0};
 
 /*
  * The name of this operator, IO count, and IO names.

--- a/bristol/blo.c
+++ b/bristol/blo.c
@@ -31,17 +31,17 @@
 
 #include "bristolblo.h"
 
-static int init = 1;
+GLOBAL_STATE static int init = 1;
 
-struct bristolBLO blo;
+GLOBAL_STATE struct bristolBLO blo;
 
-float blosine[BRISTOL_BLO_SIZE];
-float blocosine[BRISTOL_BLO_SIZE];
-float blosquare[BRISTOL_BLO_SIZE];
-float bloramp[BRISTOL_BLO_SIZE];
-float blosaw[BRISTOL_BLO_SIZE];
-float blotriangle[BRISTOL_BLO_SIZE];
-float blopulse[BRISTOL_BLO_SIZE];
+GLOBAL_STATE float blosine[BRISTOL_BLO_SIZE];
+GLOBAL_STATE float blocosine[BRISTOL_BLO_SIZE];
+GLOBAL_STATE float blosquare[BRISTOL_BLO_SIZE];
+GLOBAL_STATE float bloramp[BRISTOL_BLO_SIZE];
+GLOBAL_STATE float blosaw[BRISTOL_BLO_SIZE];
+GLOBAL_STATE float blotriangle[BRISTOL_BLO_SIZE];
+GLOBAL_STATE float blopulse[BRISTOL_BLO_SIZE];
 
 /*
  * Generate the waveforms to the given harmonic reference size. The code could

--- a/bristol/blo.c
+++ b/bristol/blo.c
@@ -33,6 +33,8 @@
 
 static int init = 1;
 
+struct bristolBLO blo;
+
 float blosine[BRISTOL_BLO_SIZE];
 float blocosine[BRISTOL_BLO_SIZE];
 float blosquare[BRISTOL_BLO_SIZE];

--- a/bristol/bristolaks.c
+++ b/bristol/bristolaks.c
@@ -43,18 +43,18 @@
  * audio threads, unless we ensure a single thread deals with any given algo
  * type, since then they are only used sequentially.
  */
-static float *freqbuf = (float *) NULL;
-static float *zerobuf = (float *) NULL;
-static float *tmpbuf = (float *) NULL;
-static float *patchbuf1 = (float *) NULL;
-static float *patchbuf2 = (float *) NULL;
+GLOBAL_STATE static float *freqbuf = (float *) NULL;
+GLOBAL_STATE static float *zerobuf = (float *) NULL;
+GLOBAL_STATE static float *tmpbuf = (float *) NULL;
+GLOBAL_STATE static float *patchbuf1 = (float *) NULL;
+GLOBAL_STATE static float *patchbuf2 = (float *) NULL;
 
 /*
  * All buffers are going to be collapsed into a single 'megabuf', this will be
  * used for all local information for every possible one of these voices. As
  * such it might get big, but will allow for arbitrary buffering.
  */
-static struct {
+GLOBAL_STATE static struct {
 	float *buf;
 	float *outputs[128][AKS_OUTCOUNT]; /* offsets into buffer for data */
 /*	float *inputs[128][AKS_INCOUNT]; pointer offsets for input source */

--- a/bristol/bristolarp2600.c
+++ b/bristol/bristolarp2600.c
@@ -36,30 +36,30 @@
  * audio threads, unless we ensure a single thread deals with any given algo
  * type, since then they are only used sequentially.
  */
-static float *fmbuf = (float *) NULL;
-static float *filtbuf = (float *) NULL;
-static float *noisebuf = (float *) NULL;
-static float *adsrbuf = (float *) NULL;
-static float *arbuf = (float *) NULL;
-static float *mixbuf = (float *) NULL;
-static float *shmix = (float *) NULL;
-static float *zerobuf = (float *) NULL;
-static float *lfosh = (float *) NULL;
-static float *lfosine = (float *) NULL;
-static float *lfosquare = (float *) NULL;
-static float *osc1ramp = (float *) NULL;
-static float *osc1puls = (float *) NULL;
-static float *osc2ramp = (float *) NULL;
-static float *osc2puls = (float *) NULL;
-static float *ringmod = (float *) NULL;
-static float *scratch = (float *) NULL;
+GLOBAL_STATE static float *fmbuf = (float *) NULL;
+GLOBAL_STATE static float *filtbuf = (float *) NULL;
+GLOBAL_STATE static float *noisebuf = (float *) NULL;
+GLOBAL_STATE static float *adsrbuf = (float *) NULL;
+GLOBAL_STATE static float *arbuf = (float *) NULL;
+GLOBAL_STATE static float *mixbuf = (float *) NULL;
+GLOBAL_STATE static float *shmix = (float *) NULL;
+GLOBAL_STATE static float *zerobuf = (float *) NULL;
+GLOBAL_STATE static float *lfosh = (float *) NULL;
+GLOBAL_STATE static float *lfosine = (float *) NULL;
+GLOBAL_STATE static float *lfosquare = (float *) NULL;
+GLOBAL_STATE static float *osc1ramp = (float *) NULL;
+GLOBAL_STATE static float *osc1puls = (float *) NULL;
+GLOBAL_STATE static float *osc2ramp = (float *) NULL;
+GLOBAL_STATE static float *osc2puls = (float *) NULL;
+GLOBAL_STATE static float *ringmod = (float *) NULL;
+GLOBAL_STATE static float *scratch = (float *) NULL;
 
 /*
  * All buffers are going to be collapsed into a single 'megabuf', this will be
  * used for all local information for every possible one of these voices. As
  * such it might get big, but will allow for arbitrary buffering.
  */
-static struct {
+GLOBAL_STATE static struct {
 	float *buf;
 	float *outputs[128][ARP_OUTCNT]; /* offsets into buffer for data */
 	float *inputs[128][ARP_INCOUNT]; /* pointer offsets for input source */

--- a/bristol/bristolaxxe.c
+++ b/bristol/bristolaxxe.c
@@ -32,16 +32,16 @@
  * audio threads, unless we ensure a single thread deals with any given algo
  * type, since then they are only used sequentially.
  */
-static float *freqbuf = (float *) NULL;
-static float *filtbuf = (float *) NULL;
-static float *noisebuf = (float *) NULL;
-static float *adsrbuf = (float *) NULL;
-static float *lfosh = (float *) NULL;
-static float *lfosine = (float *) NULL;
-static float *lfosquare = (float *) NULL;
-static float *osc1buf = (float *) NULL;
-static float *osc2buf = (float *) NULL;
-static float *scratch = (float *) NULL;
+GLOBAL_STATE static float *freqbuf = (float *) NULL;
+GLOBAL_STATE static float *filtbuf = (float *) NULL;
+GLOBAL_STATE static float *noisebuf = (float *) NULL;
+GLOBAL_STATE static float *adsrbuf = (float *) NULL;
+GLOBAL_STATE static float *lfosh = (float *) NULL;
+GLOBAL_STATE static float *lfosine = (float *) NULL;
+GLOBAL_STATE static float *lfosquare = (float *) NULL;
+GLOBAL_STATE static float *osc1buf = (float *) NULL;
+GLOBAL_STATE static float *osc2buf = (float *) NULL;
+GLOBAL_STATE static float *scratch = (float *) NULL;
 
 int
 axxeController(Baudio *baudio, u_char operator, u_char controller, float value)

--- a/bristol/bristolbitone.c
+++ b/bristol/bristolbitone.c
@@ -30,20 +30,20 @@ extern void mapVelocityCurve(int, float []);
  * audio threads, unless we ensure a single thread deals with any given algo
  * type, since then they are only used sequentially.
  */
-static float *freqbuf = (float *) NULL;
-static float *adsr1buf = (float *) NULL;
-static float *adsr2buf = (float *) NULL;
-static float *filtbuf = (float *) NULL;
-static float *dco1buf = (float *) NULL;
-static float *dco2buf = (float *) NULL;
-static float *zerobuf = (float *) NULL;
-static float *outbuf = (float *) NULL;
-static float *lfo1buf = (float *) NULL;
-static float *lfo2buf = (float *) NULL;
-static float *noisebuf = (float *) NULL;
-static float *scratchbuf = (float *) NULL;
-static float *pwmbuf = (float *) NULL;
-static float *syncbuf = (float *) NULL;
+GLOBAL_STATE static float *freqbuf = (float *) NULL;
+GLOBAL_STATE static float *adsr1buf = (float *) NULL;
+GLOBAL_STATE static float *adsr2buf = (float *) NULL;
+GLOBAL_STATE static float *filtbuf = (float *) NULL;
+GLOBAL_STATE static float *dco1buf = (float *) NULL;
+GLOBAL_STATE static float *dco2buf = (float *) NULL;
+GLOBAL_STATE static float *zerobuf = (float *) NULL;
+GLOBAL_STATE static float *outbuf = (float *) NULL;
+GLOBAL_STATE static float *lfo1buf = (float *) NULL;
+GLOBAL_STATE static float *lfo2buf = (float *) NULL;
+GLOBAL_STATE static float *noisebuf = (float *) NULL;
+GLOBAL_STATE static float *scratchbuf = (float *) NULL;
+GLOBAL_STATE static float *pwmbuf = (float *) NULL;
+GLOBAL_STATE static float *syncbuf = (float *) NULL;
 
 /*
  * These need to go into some local structure for multiple instances
@@ -68,7 +68,7 @@ static float *syncbuf = (float *) NULL;
 #define BITONE_FM			0x00004000
 #define BITONE_NO_DCO1		0x00008000
 
-typedef struct bMods {
+GLOBAL_STATE typedef struct bMods {
 	unsigned int flags;
 	float *lout;
 	float *rout;

--- a/bristol/bristolcs80.c
+++ b/bristol/bristolcs80.c
@@ -32,20 +32,20 @@ extern void mapVelocityCurve(int, float []);
  * audio threads, unless we ensure a single thread deals with any given algo
  * type, since then they are only used sequentially.
  */
-static float *freqbuf = (float *) NULL;
-static float *adsr1buf = (float *) NULL;
-static float *adsr2buf = (float *) NULL;
-static float *filtbuf = (float *) NULL;
-static float *dco1buf = (float *) NULL;
-static float *zerobuf = (float *) NULL;
-static float *outbuf = (float *) NULL;
-static float *lfo1buf = (float *) NULL;
-static float *lfo2buf = (float *) NULL;
-static float *noisebuf = (float *) NULL;
-static float *scratchbuf = (float *) NULL;
-static float *pwmbuf = (float *) NULL;
-static float *sinebuf = (float *) NULL;
-static float *modbuf = (float *) NULL;
+GLOBAL_STATE static float *freqbuf = (float *) NULL;
+GLOBAL_STATE static float *adsr1buf = (float *) NULL;
+GLOBAL_STATE static float *adsr2buf = (float *) NULL;
+GLOBAL_STATE static float *filtbuf = (float *) NULL;
+GLOBAL_STATE static float *dco1buf = (float *) NULL;
+GLOBAL_STATE static float *zerobuf = (float *) NULL;
+GLOBAL_STATE static float *outbuf = (float *) NULL;
+GLOBAL_STATE static float *lfo1buf = (float *) NULL;
+GLOBAL_STATE static float *lfo2buf = (float *) NULL;
+GLOBAL_STATE static float *noisebuf = (float *) NULL;
+GLOBAL_STATE static float *scratchbuf = (float *) NULL;
+GLOBAL_STATE static float *pwmbuf = (float *) NULL;
+GLOBAL_STATE static float *sinebuf = (float *) NULL;
+GLOBAL_STATE static float *modbuf = (float *) NULL;
 
 /*
  * These need to go into some local structure for multiple instances

--- a/bristol/bristoldx.c
+++ b/bristol/bristoldx.c
@@ -26,7 +26,7 @@
 
 extern int bristolGlobalController(struct BAudio *, u_char, u_char, float);
 
-float *lfobuf, *op0buf, *op1buf, *op2buf, *op3buf, *op4buf, *modbuf;
+GLOBAL_STATE static float *lfobuf, *op0buf, *op1buf, *op2buf, *op3buf, *op4buf, *modbuf;
 
 int
 DXGlobalController(Baudio *baudio, u_char controller,

--- a/bristol/bristolexplorer.c
+++ b/bristol/bristolexplorer.c
@@ -23,25 +23,25 @@
 #include "bristol.h"
 #include "bristolexplorer.h"
 
-static float *freqbuf = (float *) NULL;
-static float *osc3buf = (float *) NULL;
-static float *osc1buf = (float *) NULL;
-static float *noisebuf = (float *) NULL;
-static float *filtbuf = (float *) NULL;
-static float *filtbuf2 = (float *) NULL;
-static float *lfotri = (float *) NULL;
-static float *lforamp = (float *) NULL;
-static float *lfosh = (float *) NULL;
-static float *adsrbuf = (float *) NULL;
-static float *mbuf1 = (float *) NULL;
-static float *mbuf2 = (float *) NULL;
-static float *onbuf = (float *) NULL;
-static float *zerobuf = (float *) NULL;
-static float *syncbuf = (float *) NULL;
+GLOBAL_STATE static float *freqbuf = (float *) NULL;
+GLOBAL_STATE static float *osc3buf = (float *) NULL;
+GLOBAL_STATE static float *osc1buf = (float *) NULL;
+GLOBAL_STATE static float *noisebuf = (float *) NULL;
+GLOBAL_STATE static float *filtbuf = (float *) NULL;
+GLOBAL_STATE static float *filtbuf2 = (float *) NULL;
+GLOBAL_STATE static float *lfotri = (float *) NULL;
+GLOBAL_STATE static float *lforamp = (float *) NULL;
+GLOBAL_STATE static float *lfosh = (float *) NULL;
+GLOBAL_STATE static float *adsrbuf = (float *) NULL;
+GLOBAL_STATE static float *mbuf1 = (float *) NULL;
+GLOBAL_STATE static float *mbuf2 = (float *) NULL;
+GLOBAL_STATE static float *onbuf = (float *) NULL;
+GLOBAL_STATE static float *zerobuf = (float *) NULL;
+GLOBAL_STATE static float *syncbuf = (float *) NULL;
 
 extern int buildCurrentTable(Baudio *, float);
 
-extern int s440holder;
+GLOBAL_STATE extern int s440holder;
 
 static int
 expGlobalController(Baudio *baudio, u_char controller,

--- a/bristol/bristolgranular.c
+++ b/bristol/bristolgranular.c
@@ -41,26 +41,26 @@
 #include "bristol.h"
 #include "granular.h"
 
-static float *freqbuf = (float *) NULL;
+GLOBAL_STATE static float *freqbuf = (float *) NULL;
 
-static float *zerobuf = (float *) NULL;
+GLOBAL_STATE static float *zerobuf = (float *) NULL;
 
-static float *lfobuf = (float *) NULL;
-static float *noisebuf = (float *) NULL;
+GLOBAL_STATE static float *lfobuf = (float *) NULL;
+GLOBAL_STATE static float *noisebuf = (float *) NULL;
 
-static float *adsrbuf = (float *) NULL;
+GLOBAL_STATE static float *adsrbuf = (float *) NULL;
 
-static float *bus1buf = (float *) NULL;
-static float *bus2buf = (float *) NULL;
-static float *bus3buf = (float *) NULL;
-static float *bus4buf = (float *) NULL;
-static float *bus5buf = (float *) NULL;
-static float *bus6buf = (float *) NULL;
-static float *bus7buf = (float *) NULL;
-static float *bus8buf = (float *) NULL;
-static float *bus9buf = (float *) NULL;
+GLOBAL_STATE static float *bus1buf = (float *) NULL;
+GLOBAL_STATE static float *bus2buf = (float *) NULL;
+GLOBAL_STATE static float *bus3buf = (float *) NULL;
+GLOBAL_STATE static float *bus4buf = (float *) NULL;
+GLOBAL_STATE static float *bus5buf = (float *) NULL;
+GLOBAL_STATE static float *bus6buf = (float *) NULL;
+GLOBAL_STATE static float *bus7buf = (float *) NULL;
+GLOBAL_STATE static float *bus8buf = (float *) NULL;
+GLOBAL_STATE static float *bus9buf = (float *) NULL;
 
-static float *busbuf[9];
+GLOBAL_STATE static float *busbuf[9];
 
 extern int bristolGlobalController(struct BAudio *, u_char, u_char, float);
 extern int buildCurrentTable(Baudio *, float);

--- a/bristol/bristolhammond.c
+++ b/bristol/bristolhammond.c
@@ -24,10 +24,10 @@
 #include "bristol.h"
 #include "rotary.h"
 
-static float *tmpbuf1 = (float *) NULL;
-static float *tmpbuf2 = (float *) NULL;
-static float *tmpbuf3 = (float *) NULL;
-static float *tmpbuf4 = (float *) NULL;
+GLOBAL_STATE static float *tmpbuf1 = (float *) NULL;
+GLOBAL_STATE static float *tmpbuf2 = (float *) NULL;
+GLOBAL_STATE static float *tmpbuf3 = (float *) NULL;
+GLOBAL_STATE static float *tmpbuf4 = (float *) NULL;
 
 #define HAMMOND_VIBRA 0x01
 #define HAMMOND_SERMON 0x02
@@ -35,7 +35,7 @@ static float *tmpbuf4 = (float *) NULL;
 extern int bristolGlobalController(struct BAudio *, u_char, u_char, float);
 extern int initthesermon(int, int, int);
 
-static int sineform = 0, samplecount, samplerate;
+GLOBAL_STATE static int sineform = 0, samplecount, samplerate;
 static int operateHammondPostops();
 
 int
@@ -208,7 +208,7 @@ extern void therequiem(float *, float *, int);
  * call will find this zeroed. Apart from that, at 500mips per go, thesermon()
  * is rather heavyweight.
  */
-int dosermon = 1;
+GLOBAL_STATE static int dosermon = 1;
 
 int
 operateHammondPreops(audioMain *audiomain, Baudio *baudio,
@@ -253,8 +253,8 @@ bristolVoice *voice, register float *startbuf)
 }
 
 /* Should bury this somewhere..... */
-float pbHLast;
-float pbLLast;
+GLOBAL_STATE static float pbHLast;
+GLOBAL_STATE static float pbLLast;
 
 static int
 operateHammondPostops(audioMain *audiomain, Baudio *baudio,

--- a/bristol/bristoljuno.c
+++ b/bristol/bristoljuno.c
@@ -29,19 +29,19 @@
  * audio threads, unless we ensure a single thread deals with any given algo
  * type, since then they are only used sequentially.
  */
-static float *freqbuf = (float *) NULL;
-static float *pmodbuf = (float *) NULL;
-static float *adsrbuf = (float *) NULL;
-static float *filtbuf = (float *) NULL;
-static float *oscbbuf = (float *) NULL;
-static float *oscabuf = (float *) NULL;
-static float *sbuf = (float *) NULL;
+GLOBAL_STATE static float *freqbuf = (float *) NULL;
+GLOBAL_STATE static float *pmodbuf = (float *) NULL;
+GLOBAL_STATE static float *adsrbuf = (float *) NULL;
+GLOBAL_STATE static float *filtbuf = (float *) NULL;
+GLOBAL_STATE static float *oscbbuf = (float *) NULL;
+GLOBAL_STATE static float *oscabuf = (float *) NULL;
+GLOBAL_STATE static float *sbuf = (float *) NULL;
 
 /*
  * These need to go into some local structure for multiple instances
  * of the juno - malloc()ed into the baudio->mixlocals.
  */
-typedef struct jMods {
+GLOBAL_STATE typedef struct jMods {
 	float lfo_fgain;
 	unsigned int flags;
 	void *lfolocals;
@@ -60,7 +60,7 @@ typedef struct jMods {
 	int chspeed;
 } jmods;
 
-extern int s440holder;
+GLOBAL_STATE extern int s440holder;
 
 int
 junoController(Baudio *baudio, u_char operator,

--- a/bristol/bristoljupiter.c
+++ b/bristol/bristoljupiter.c
@@ -31,22 +31,22 @@ extern void mapVelocityCurve(int, float []);
  * audio threads, unless we ensure a single thread deals with any given algo
  * type, since then they are only used sequentially.
  */
-static float *freqbuf = (float *) NULL;
-static float *adsr1buf = (float *) NULL;
-static float *adsr2buf = (float *) NULL;
-static float *filtbuf = (float *) NULL;
-static float *dco1buf = (float *) NULL;
-static float *dco2buf = (float *) NULL;
-static float *zerobuf = (float *) NULL;
-static float *outbuf = (float *) NULL;
-static float *lfo1buf = (float *) NULL;
-static float *lfo2buf = (float *) NULL;
-static float *noisebuf = (float *) NULL;
-static float *scratchbuf = (float *) NULL;
-static float *pwmbuf = (float *) NULL;
-static float *vcofmbuf = (float *) NULL;
-static float *modbuf = (float *) NULL;
-static float *syncbuf = (float *) NULL;
+GLOBAL_STATE static float *freqbuf = (float *) NULL;
+GLOBAL_STATE static float *adsr1buf = (float *) NULL;
+GLOBAL_STATE static float *adsr2buf = (float *) NULL;
+GLOBAL_STATE static float *filtbuf = (float *) NULL;
+GLOBAL_STATE static float *dco1buf = (float *) NULL;
+GLOBAL_STATE static float *dco2buf = (float *) NULL;
+GLOBAL_STATE static float *zerobuf = (float *) NULL;
+GLOBAL_STATE static float *outbuf = (float *) NULL;
+GLOBAL_STATE static float *lfo1buf = (float *) NULL;
+GLOBAL_STATE static float *lfo2buf = (float *) NULL;
+GLOBAL_STATE static float *noisebuf = (float *) NULL;
+GLOBAL_STATE static float *scratchbuf = (float *) NULL;
+GLOBAL_STATE static float *pwmbuf = (float *) NULL;
+GLOBAL_STATE static float *vcofmbuf = (float *) NULL;
+GLOBAL_STATE static float *modbuf = (float *) NULL;
+GLOBAL_STATE static float *syncbuf = (float *) NULL;
 
 /*
  * These need to go into some local structure for multiple instances
@@ -76,7 +76,7 @@ static float *syncbuf = (float *) NULL;
 #define JUPITER_XMOD_ENV	0x00200000
 #define JUPITER_MOD_ENABLE	0x00400000
 
-typedef struct bMods {
+GLOBAL_STATE typedef struct bMods {
 	unsigned int flags;
 	float *lout;
 	float *rout;
@@ -397,7 +397,7 @@ u_char controller, float value)
  * track the most recent velocity at the expense of envelope retriggers. At
  * steady state the envelope should continue to open as expected.
  */
-static int lfo1exclusion = 0;
+GLOBAL_STATE static int lfo1exclusion = 0;
 
 int
 jupiterPreops(audioMain *audiomain, Baudio *baudio,

--- a/bristol/bristolmemorymoog.c
+++ b/bristol/bristolmemorymoog.c
@@ -41,16 +41,16 @@ extern int buildCurrentTable(Baudio *, float);
  * could be used here (noise, LFO, but polyphonic parameters would have to be
  * buried in the voice local structure.
  */
-static float *freqbuf = (float *) NULL;
-static float *filtbuf = (float *) NULL;
-static float *noisebuf = (float *) NULL;
-static float *adsrbuf = (float *) NULL;
-static float *osc1buf = (float *) NULL;
-static float *osc2buf = (float *) NULL;
-static float *osc3buf = (float *) NULL;
-static float *lfobuf = (float *) NULL;
-static float *modbuf = (float *) NULL;
-static float *scratch = (float *) NULL;
+GLOBAL_STATE static float *freqbuf = (float *) NULL;
+GLOBAL_STATE static float *filtbuf = (float *) NULL;
+GLOBAL_STATE static float *noisebuf = (float *) NULL;
+GLOBAL_STATE static float *adsrbuf = (float *) NULL;
+GLOBAL_STATE static float *osc1buf = (float *) NULL;
+GLOBAL_STATE static float *osc2buf = (float *) NULL;
+GLOBAL_STATE static float *osc3buf = (float *) NULL;
+GLOBAL_STATE static float *lfobuf = (float *) NULL;
+GLOBAL_STATE static float *modbuf = (float *) NULL;
+GLOBAL_STATE static float *scratch = (float *) NULL;
 
 #define PEDAL1 baudio->contcontroller[7] /* GM-2 Volume pedal */
 #define PEDAL2 baudio->contcontroller[11] /* GM-2 Expression pedal */

--- a/bristol/bristolmm.c
+++ b/bristol/bristolmm.c
@@ -24,13 +24,13 @@
 #include "bristolmm.h"
 #include "bristolmidi.h"
 
-static float *freqbuf = (float *) NULL;
-static float *modbuf = (float *) NULL;
-static float *osc3buf = (float *) NULL;
-static float *noisebuf = (float *) NULL;
-static float *scratch = (float *) NULL;
+GLOBAL_STATE static float *freqbuf = (float *) NULL;
+GLOBAL_STATE static float *modbuf = (float *) NULL;
+GLOBAL_STATE static float *osc3buf = (float *) NULL;
+GLOBAL_STATE static float *noisebuf = (float *) NULL;
+GLOBAL_STATE static float *scratch = (float *) NULL;
 
-extern int s440holder;
+GLOBAL_STATE extern int s440holder;
 
 int
 bristolGlobalController(Baudio *baudio, u_char controller,

--- a/bristol/bristolobx.c
+++ b/bristol/bristolobx.c
@@ -31,20 +31,20 @@
  *
  * (This file was copied from the prophet, hence shares much of the code)
  */
-static float *freq = (float *) NULL;
-static float *freqbuf = (float *) NULL;
-static float *adsrbuf = (float *) NULL;
-static float *filtbuf = (float *) NULL;
-static float *noisebuf = (float *) NULL;
-static float *oscbbuf = (float *) NULL;
-static float *oscabuf = (float *) NULL;
-static float *scratchbuf = (float *) NULL;
+GLOBAL_STATE static float *freq = (float *) NULL;
+GLOBAL_STATE static float *freqbuf = (float *) NULL;
+GLOBAL_STATE static float *adsrbuf = (float *) NULL;
+GLOBAL_STATE static float *filtbuf = (float *) NULL;
+GLOBAL_STATE static float *noisebuf = (float *) NULL;
+GLOBAL_STATE static float *oscbbuf = (float *) NULL;
+GLOBAL_STATE static float *oscabuf = (float *) NULL;
+GLOBAL_STATE static float *scratchbuf = (float *) NULL;
 
-static float *lfosqr = (float *) NULL;
-static float *lfo = (float *) NULL;
-static float *lfosine = (float *) NULL;
-static float *modsine = (float *) NULL;
-static float *lfosh = (float *) NULL;
+GLOBAL_STATE static float *lfosqr = (float *) NULL;
+GLOBAL_STATE static float *lfo = (float *) NULL;
+GLOBAL_STATE static float *lfosine = (float *) NULL;
+GLOBAL_STATE static float *modsine = (float *) NULL;
+GLOBAL_STATE static float *lfosh = (float *) NULL;
 
 int
 obxController(Baudio *baudio, u_char operator, u_char controller, float value)

--- a/bristol/bristolodyssey.c
+++ b/bristol/bristolodyssey.c
@@ -40,25 +40,25 @@
  * audio threads, unless we ensure a single thread deals with any given algo
  * type, since then they are only used sequentially.
  */
-static float *freqbuf = (float *) NULL;
-static float *fmbuf = (float *) NULL;
-static float *filtbuf = (float *) NULL;
-static float *noisebuf = (float *) NULL;
-static float *adsrbuf = (float *) NULL;
-static float *arbuf = (float *) NULL;
-static float *mixbuf = (float *) NULL;
-static float *shmix = (float *) NULL;
-static float *zerobuf = (float *) NULL;
-static float *lfosh = (float *) NULL;
-static float *lfosine = (float *) NULL;
-static float *lfosquare = (float *) NULL;
-static float *osc1ramp = (float *) NULL;
-static float *osc1puls = (float *) NULL;
-static float *osc2ramp = (float *) NULL;
-static float *osc2puls = (float *) NULL;
-static float *ringmod = (float *) NULL;
+GLOBAL_STATE static float *freqbuf = (float *) NULL;
+GLOBAL_STATE static float *fmbuf = (float *) NULL;
+GLOBAL_STATE static float *filtbuf = (float *) NULL;
+GLOBAL_STATE static float *noisebuf = (float *) NULL;
+GLOBAL_STATE static float *adsrbuf = (float *) NULL;
+GLOBAL_STATE static float *arbuf = (float *) NULL;
+GLOBAL_STATE static float *mixbuf = (float *) NULL;
+GLOBAL_STATE static float *shmix = (float *) NULL;
+GLOBAL_STATE static float *zerobuf = (float *) NULL;
+GLOBAL_STATE static float *lfosh = (float *) NULL;
+GLOBAL_STATE static float *lfosine = (float *) NULL;
+GLOBAL_STATE static float *lfosquare = (float *) NULL;
+GLOBAL_STATE static float *osc1ramp = (float *) NULL;
+GLOBAL_STATE static float *osc1puls = (float *) NULL;
+GLOBAL_STATE static float *osc2ramp = (float *) NULL;
+GLOBAL_STATE static float *osc2puls = (float *) NULL;
+GLOBAL_STATE static float *ringmod = (float *) NULL;
 
-static float *scratch = (float *) NULL;
+GLOBAL_STATE static float *scratch = (float *) NULL;
 
 static void
 oSwitchMod(odysseymods *mods, int ind, float value, float *b1, float *b2)

--- a/bristol/bristolpoly.c
+++ b/bristol/bristolpoly.c
@@ -38,15 +38,15 @@
 /*
  * Buffer requirements.
  */
-static float *freqbuf = (float *) NULL;
-static float *scratchbuf = (float *) NULL;
-static float *osc0buf = (float *) NULL;
-static float *osc1buf = (float *) NULL;
-static float *osc2buf = (float *) NULL;
-static float *osc3buf = (float *) NULL;
-static float *adsrbuf = (float *) NULL;
-static float *mg1buf = (float *) NULL;
-static float *mg2buf = (float *) NULL;
+GLOBAL_STATE static float *freqbuf = (float *) NULL;
+GLOBAL_STATE static float *scratchbuf = (float *) NULL;
+GLOBAL_STATE static float *osc0buf = (float *) NULL;
+GLOBAL_STATE static float *osc1buf = (float *) NULL;
+GLOBAL_STATE static float *osc2buf = (float *) NULL;
+GLOBAL_STATE static float *osc3buf = (float *) NULL;
+GLOBAL_STATE static float *adsrbuf = (float *) NULL;
+GLOBAL_STATE static float *mg1buf = (float *) NULL;
+GLOBAL_STATE static float *mg2buf = (float *) NULL;
 
 int
 polyController(Baudio *baudio, u_char operator, u_char controller, float value)

--- a/bristol/bristolpoly6.c
+++ b/bristol/bristolpoly6.c
@@ -32,14 +32,14 @@
  * audio threads, unless we ensure a single thread deals with any given algo
  * type, since then they are only used sequentially.
  */
-static float *freqbuf = (float *) NULL;
-static float *filtbuf = (float *) NULL;
-static float *noisebuf = (float *) NULL;
-static float *pmodbuf = (float *) NULL;
-static float *adsrbuf = (float *) NULL;
-static float *oscabuf = (float *) NULL;
-static float *mgbuf = (float *) NULL;
-static float *lfobuf = (float *) NULL;
+GLOBAL_STATE static float *freqbuf = (float *) NULL;
+GLOBAL_STATE static float *filtbuf = (float *) NULL;
+GLOBAL_STATE static float *noisebuf = (float *) NULL;
+GLOBAL_STATE static float *pmodbuf = (float *) NULL;
+GLOBAL_STATE static float *adsrbuf = (float *) NULL;
+GLOBAL_STATE static float *oscabuf = (float *) NULL;
+GLOBAL_STATE static float *mgbuf = (float *) NULL;
+GLOBAL_STATE static float *lfobuf = (float *) NULL;
 
 int
 poly6Controller(Baudio *baudio, u_char operator, u_char controller, float value)

--- a/bristol/bristolprophet1.c
+++ b/bristol/bristolprophet1.c
@@ -31,23 +31,23 @@
  *
  * These should really be hidden in the pMods structure for multiple instances.
  */
-static float *freqbuf = (float *) NULL;
-static float *tfreqbuf = (float *) NULL;
-static float *lfobuf = (float *) NULL;
-static float *wmodbuf = (float *) NULL;
-static float *dmodbuf = (float *) NULL;
-static float *adsrbuf = (float *) NULL;
-static float *filtbuf = (float *) NULL;
-static float *noisebuf = (float *) NULL;
-static float *oscbbuf = (float *) NULL;
-static float *oscabuf = (float *) NULL;
-static float *scratchbuf = (float *) NULL;
+GLOBAL_STATE static float *freqbuf = (float *) NULL;
+GLOBAL_STATE static float *tfreqbuf = (float *) NULL;
+GLOBAL_STATE static float *lfobuf = (float *) NULL;
+GLOBAL_STATE static float *wmodbuf = (float *) NULL;
+GLOBAL_STATE static float *dmodbuf = (float *) NULL;
+GLOBAL_STATE static float *adsrbuf = (float *) NULL;
+GLOBAL_STATE static float *filtbuf = (float *) NULL;
+GLOBAL_STATE static float *noisebuf = (float *) NULL;
+GLOBAL_STATE static float *oscbbuf = (float *) NULL;
+GLOBAL_STATE static float *oscabuf = (float *) NULL;
+GLOBAL_STATE static float *scratchbuf = (float *) NULL;
 
-static float *tribuf = (float *) NULL;
-static float *sqrbuf = (float *) NULL;
-static float *rampbuf = (float *) NULL;
+GLOBAL_STATE static float *tribuf = (float *) NULL;
+GLOBAL_STATE static float *sqrbuf = (float *) NULL;
+GLOBAL_STATE static float *rampbuf = (float *) NULL;
 
-extern int s440holder;
+GLOBAL_STATE extern int s440holder;
 
 int
 pro1Controller(Baudio *baudio, u_char operator, u_char controller,

--- a/bristol/bristolprophet52.c
+++ b/bristol/bristolprophet52.c
@@ -23,78 +23,12 @@
 #include "bristolmm.h"
 #include "bristolprophet.h"
 
-extern int operateOneProphet(audioMain *, Baudio *, bristolVoice *, float *);
-extern int prophetController(Baudio *, u_char, u_char, float);
-extern int operateProphetPreops(audioMain *, Baudio *, bristolVoice *, float *);
-extern int bristolProphetDestroy(audioMain *, Baudio *);
-
-extern float *freqbuf;
-extern float *osc3buf;
-extern float *wmodbuf;
-extern float *pmodbuf;
-extern float *adsrbuf;
-extern float *filtbuf;
-extern float *noisebuf;
-extern float *oscbbuf;
-extern float *oscabuf;
-extern float *scratchbuf;
+extern int
+bristolProphetInitModel(audioMain *audiomain, Baudio *baudio, int model);
 
 int
 bristolProphet52Init(audioMain *audiomain, Baudio *baudio)
 {
-printf("initialising one prophet\n");
-	baudio->soundCount = 8; /* Number of operators in this voice (MM) */
-	/*
-	 * Assign an array of sound pointers.
-	 */
-	baudio->sound = (bristolSound **)
-		bristolmalloc0(sizeof(bristolOP *) * baudio->soundCount);
-	baudio->effect = (bristolSound **)
-		bristolmalloc0(sizeof(bristolOP *) * baudio->soundCount);
-
-	initSoundAlgo(8, 0, baudio, audiomain, baudio->sound);
-	initSoundAlgo(8, 1, baudio, audiomain, baudio->sound);
-	initSoundAlgo(16, 2, baudio, audiomain, baudio->sound);
-	/* An ADSR */
-	initSoundAlgo(1, 3, baudio, audiomain, baudio->sound);
-	/* A filter */
-	initSoundAlgo(3, 4, baudio, audiomain, baudio->sound);
-	/* Another ADSR */
-	initSoundAlgo(1, 5, baudio, audiomain, baudio->sound);
-	/* An amplifier */
-	initSoundAlgo(2, 6, baudio, audiomain, baudio->sound);
-	/* An noise source */
-	initSoundAlgo(4, 7, baudio, audiomain, baudio->sound);
-
-	baudio->param = prophetController;
-	baudio->destroy = bristolProphetDestroy;
-	baudio->operate = operateOneProphet;
-	baudio->preops = operateProphetPreops;
-
-	/*
-	 * Put in a vibrachorus on our effects list.
-	 */
-	initSoundAlgo(12, 0, baudio, audiomain, baudio->effect);
-
-	if (freqbuf == 0)
-		freqbuf = (float *) bristolmalloc0(audiomain->segmentsize);
-	if (scratchbuf == 0)
-		scratchbuf = (float *) bristolmalloc0(audiomain->segmentsize);
-	if (pmodbuf == 0)
-		pmodbuf = (float *) bristolmalloc0(audiomain->segmentsize);
-	if (adsrbuf == 0)
-		adsrbuf = (float *) bristolmalloc0(audiomain->segmentsize);
-	if (filtbuf == 0)
-		filtbuf = (float *) bristolmalloc0(audiomain->segmentsize);
-	if (oscbbuf == 0)
-		oscbbuf = (float *) bristolmalloc0(audiomain->segmentsize);
-	if (oscabuf == 0)
-		oscabuf = (float *) bristolmalloc0(audiomain->segmentsize);
-
-	baudio->mixlocals = (float *) bristolmalloc0(sizeof(pmods));
-	((pmods *) baudio->mixlocals)->pan = 0.0;
-//	baudio->mixflags |= BRISTOL_STEREO;
-	baudio->mixflags |= P_UNISON;
-	return(0);
+	return bristolProphetInitModel(audiomain, baudio, 52);
 }
 

--- a/bristol/bristolrealistic.c
+++ b/bristol/bristolrealistic.c
@@ -32,22 +32,22 @@
  * audio threads, unless we ensure a single thread deals with any given algo
  * type, since then they are only used sequentially.
  */
-static float *freqbuf = (float *) NULL;
-static float *pfreqbuf = (float *) NULL;
-static float *filtbuf = (float *) NULL;
-static float *noisebuf = (float *) NULL;
-static float *padsrbuf = (float *) NULL;
-static float *adsrbuf = (float *) NULL;
-static float *lfosh = (float *) NULL;
-static float *lforamp = (float *) NULL;
-static float *lfosquare = (float *) NULL;
-static float *osc1buf = (float *) NULL;
-static float *osc2buf = (float *) NULL;
-static float *oscpbuf = (float *) NULL;
-static float *scratch = (float *) NULL;
-static float *zerobuf = (float *) NULL;
+GLOBAL_STATE static float *freqbuf = (float *) NULL;
+GLOBAL_STATE static float *pfreqbuf = (float *) NULL;
+GLOBAL_STATE static float *filtbuf = (float *) NULL;
+GLOBAL_STATE static float *noisebuf = (float *) NULL;
+GLOBAL_STATE static float *padsrbuf = (float *) NULL;
+GLOBAL_STATE static float *adsrbuf = (float *) NULL;
+GLOBAL_STATE static float *lfosh = (float *) NULL;
+GLOBAL_STATE static float *lforamp = (float *) NULL;
+GLOBAL_STATE static float *lfosquare = (float *) NULL;
+GLOBAL_STATE static float *osc1buf = (float *) NULL;
+GLOBAL_STATE static float *osc2buf = (float *) NULL;
+GLOBAL_STATE static float *oscpbuf = (float *) NULL;
+GLOBAL_STATE static float *scratch = (float *) NULL;
+GLOBAL_STATE static float *zerobuf = (float *) NULL;
 
-static float *modbuf;
+GLOBAL_STATE static float *modbuf;
 
 int
 mg1Controller(Baudio *baudio, u_char operator, u_char controller, float value)

--- a/bristol/bristolroadrunner.c
+++ b/bristol/bristolroadrunner.c
@@ -24,12 +24,12 @@
 #include "bristol.h"
 #include "roadrunner.h"
 
-static float *freqbuf = (float *) NULL;
-static float *modbuf = (float *) NULL;
-static float *sawbuf = (float *) NULL;
-static float *tribuf = (float *) NULL;
-static float *sqrbuf = (float *) NULL;
-static float *lfobuf = (float *) NULL;
+GLOBAL_STATE static float *freqbuf = (float *) NULL;
+GLOBAL_STATE static float *modbuf = (float *) NULL;
+GLOBAL_STATE static float *sawbuf = (float *) NULL;
+GLOBAL_STATE static float *tribuf = (float *) NULL;
+GLOBAL_STATE static float *sqrbuf = (float *) NULL;
+GLOBAL_STATE static float *lfobuf = (float *) NULL;
 
 extern int bristolGlobalController(struct BAudio *, u_char, u_char, float);
 extern int buildCurrentTable(Baudio *, float);

--- a/bristol/bristolsampler.c
+++ b/bristol/bristolsampler.c
@@ -29,19 +29,19 @@
  * audio threads, unless we ensure a single thread deals with any given algo
  * type, since then they are only used sequencially.
  */
-static float *freqbuf = (float *) NULL;
-static float *pmodbuf = (float *) NULL;
-static float *adsrbuf = (float *) NULL;
-static float *filtbuf = (float *) NULL;
-static float *oscbbuf = (float *) NULL;
-static float *oscabuf = (float *) NULL;
-static float *sbuf = (float *) NULL;
+GLOBAL_STATE static float *freqbuf = (float *) NULL;
+GLOBAL_STATE static float *pmodbuf = (float *) NULL;
+GLOBAL_STATE static float *adsrbuf = (float *) NULL;
+GLOBAL_STATE static float *filtbuf = (float *) NULL;
+GLOBAL_STATE static float *oscbbuf = (float *) NULL;
+GLOBAL_STATE static float *oscabuf = (float *) NULL;
+GLOBAL_STATE static float *sbuf = (float *) NULL;
 
 /*
  * These need to go into some local structure for multiple instances
  * of the sampler - malloc()ed into the baudio->mixlocals.
  */
-typedef struct jMods {
+GLOBAL_STATE typedef struct jMods {
 	float lfo_fgain;
 	unsigned int flags;
 	void *lfolocals;
@@ -60,7 +60,7 @@ typedef struct jMods {
 	int chspeed;
 } jmods;
 
-extern int s440holder;
+GLOBAL_STATE extern int s440holder;
 
 int
 samplerController(Baudio *baudio, u_char operator,

--- a/bristol/bristolsolina.c
+++ b/bristol/bristolsolina.c
@@ -24,11 +24,11 @@
 #include "bristol.h"
 #include "solina.h"
 
-static float *freqbuf = (float *) NULL;
-static float *zerobuf = (float *) NULL;
-static float *sawbuf = (float *) NULL;
-static float *sqrbuf = (float *) NULL;
-static float *lfobuf = (float *) NULL;
+GLOBAL_STATE static float *freqbuf = (float *) NULL;
+GLOBAL_STATE static float *zerobuf = (float *) NULL;
+GLOBAL_STATE static float *sawbuf = (float *) NULL;
+GLOBAL_STATE static float *sqrbuf = (float *) NULL;
+GLOBAL_STATE static float *lfobuf = (float *) NULL;
 
 extern int bristolGlobalController(struct BAudio *, u_char, u_char, float);
 extern int buildCurrentTable(Baudio *, float);

--- a/bristol/bristolsystem.c
+++ b/bristol/bristolsystem.c
@@ -36,7 +36,7 @@ extern int bristolJackInterface();
 #endif
 extern void allNotesOff();
 
-static int initCount = 0;
+GLOBAL_STATE static int initCount = 0;
 
 int
 bristolgetsid(Baudio *baudio, int sid)

--- a/bristol/bristolvox.c
+++ b/bristol/bristolvox.c
@@ -23,13 +23,13 @@
 
 #include "bristol.h"
 
-static float *tmpbuf1 = (float *) NULL;
-static float *vbuf = (float *) NULL;
-static float *outbuf = (float *) NULL;
-static float *percbuf = (float *) NULL;
-static float *percenv = (float *) NULL;
-static float *bassbuf = (float *) NULL;
-static float *bassenv = (float *) NULL;
+GLOBAL_STATE static float *tmpbuf1 = (float *) NULL;
+GLOBAL_STATE static float *vbuf = (float *) NULL;
+GLOBAL_STATE static float *outbuf = (float *) NULL;
+GLOBAL_STATE static float *percbuf = (float *) NULL;
+GLOBAL_STATE static float *percenv = (float *) NULL;
+GLOBAL_STATE static float *bassbuf = (float *) NULL;
+GLOBAL_STATE static float *bassenv = (float *) NULL;
 
 #define VOX_VIBRA		0x01
 #define VOX_VIBRA_DONE	0x02
@@ -88,7 +88,7 @@ baudio->effect[0]->param->param[5].float_val);
 	return(0);
 }
 
-int vibraDone = 0;
+GLOBAL_STATE static int vibraDone = 0;
 
 /*
  * This will only do the envelopes for the Dual manual. It will cover the

--- a/bristol/cs80env.c
+++ b/bristol/cs80env.c
@@ -36,7 +36,7 @@
 #include "bristol.h"
 #include "envelope.h"
 
-static float sr;
+GLOBAL_STATE static float sr;
 
 /*
  * The name of this operator, IO count, and IO names.

--- a/bristol/cs80osc.c
+++ b/bristol/cs80osc.c
@@ -41,8 +41,8 @@
 #include "cs80osc.h"
 #include "bristolcs80.h"
 
-float note_diff;
-int samplecount;
+GLOBAL_STATE static float note_diff;
+GLOBAL_STATE static int samplecount;
 
 static void fillWave(float *, int, int);
 static void buildCs80Sound(bristolOP *, bristolOPParams *);
@@ -64,7 +64,7 @@ static void buildCs80Sound(bristolOP *, bristolOPParams *);
 {16', 8', 5-1/3', 4, 2-2/3', 2', 0,0,0,0,0,0,0};
 static float sweeps[16] = {1, 2, 3, 4, 6, 8, 8, 8, 8, 8, 4,4,4,4,4,8};
  */
-static float sweeps[16] = {2, 4, 6, 8, 12, 16, 8, 8, 8, 8, 4,4,4,4,4,8};
+static const float sweeps[16] = {2, 4, 6, 8, 12, 16, 8, 8, 8, 8, 4,4,4,4,4,8};
 
 /*
  * The name of this operator, IO count, and IO names.

--- a/bristol/dco.c
+++ b/bristol/dco.c
@@ -39,7 +39,7 @@
 #include "bristolblo.h"
 #include "dco.h"
 
-float note_diff;
+GLOBAL_STATE static float note_diff;
 
 /*
  * The name of this operator, IO count, and IO names.

--- a/bristol/dimensionD.c
+++ b/bristol/dimensionD.c
@@ -96,7 +96,7 @@ static int param(bristolOP *operator, bristolOPParams *param,
 	return(0);
 }
 
-static float sinewave[1024];
+GLOBAL_STATE static float sinewave[1024];
 
 /*
  * Reset any local memory information.

--- a/bristol/dxop.c
+++ b/bristol/dxop.c
@@ -38,7 +38,7 @@
 #include "bristol.h"
 #include "dxop.h"
 
-static float note_diff;
+GLOBAL_STATE static float note_diff;
 
 /*
  * The name of this operator, IO count, and IO names.

--- a/bristol/env5stage.c
+++ b/bristol/env5stage.c
@@ -51,7 +51,7 @@
 #include "bristol.h"
 #include "env5stage.h"
 
-static float samplerate = 0;
+GLOBAL_STATE static float samplerate = 0;
 
 /*
  * The name of this operator, IO count, and IO names.

--- a/bristol/expdco.c
+++ b/bristol/expdco.c
@@ -40,7 +40,7 @@
 #include "bristolblo.h"
 #include "expdco.h"
 
-float note_diff;
+GLOBAL_STATE static float note_diff;
 
 /*
  * The name of this operator, IO count, and IO names.
@@ -59,7 +59,7 @@ float note_diff;
 #define DCO_WAVE_COUNT 6
 
 static void fillWave();
-static float *sbuf = NULL;
+GLOBAL_STATE static float *sbuf = NULL;
 
 /*
  * Reset any local memory information.

--- a/bristol/filter.c
+++ b/bristol/filter.c
@@ -61,7 +61,7 @@
 #define FILTER_MOD_IND 1
 #define FILTER_OUT_IND 2
 
-static float srate;
+GLOBAL_STATE static float srate;
 
 /*
  * When this uses cfreq we get very good keyboard tracking as cfreq is a true
@@ -145,7 +145,7 @@ static int destroy(bristolOP *operator)
 }
 
 #define ROOT2 1.4142135623730950488
-double pidsr;
+GLOBAL_STATE static double pidsr;
 
 /*
  * Reset any local memory information.

--- a/bristol/filter2.c
+++ b/bristol/filter2.c
@@ -73,7 +73,7 @@
 #define FILTER_OUT_IND 2
 
 /* This is ugly, we shuold correctly pull it out of the operator template */
-static float srate;
+GLOBAL_STATE static float srate;
 
 #define _f_lim_r (20000 / (sr * 2)) /* Upper limit with resampling */
 #define _f_lim (20000 / sr)
@@ -147,7 +147,7 @@ static int destroy(bristolOP *operator)
 }
 
 #define ROOT2 1.4142135623730950488
-double pidsr;
+GLOBAL_STATE static double pidsr;
 
 /*
  * Reset any local memory information.
@@ -352,9 +352,9 @@ chamberlain(float *ib, float *mb, float *ob, bristolOPParams *param, bristolFILT
 	return(0);
 }
 
-static float scale = 0.0000001; // 0.000000001;
-static int dngx1 = 0x67452301;
-static int dngx2 = 0xefcdab89;
+static const float scale = 0.0000001; // 0.000000001;
+GLOBAL_STATE static int dngx1 = 0x67452301;
+GLOBAL_STATE static int dngx2 = 0xefcdab89;
 
 static int
 huovilainen24(float *ib, float *mb, float *ob, bristolOPParams *param, bristolFILTERlocal *local, bristolVoice *voice, int count)

--- a/bristol/granulardco.c
+++ b/bristol/granulardco.c
@@ -38,8 +38,8 @@
 #include "bristol.h"
 #include "granulardco.h"
 
-float note_diff;
-float samplerate;
+GLOBAL_STATE static float note_diff;
+GLOBAL_STATE static float samplerate;
 
 #define BRISTOL_SQR 4
 
@@ -322,23 +322,23 @@ printf("threads %i\n", param->param[index].int_val);
  * It could be fixed, the issue is that 'regrain()' needs to change the run
  * time parameters and this was an easy option for now.
  */
-static float gg;
-static float *cwt;
-static float gtp;
-static float cdt;
-static float gts;
-static float wtp;
-static float wtr;
-static float wts;
-static float *gmb;
-static float *wmb;
+GLOBAL_STATE static float gg;
+GLOBAL_STATE static float *cwt;
+GLOBAL_STATE static float gtp;
+GLOBAL_STATE static float cdt;
+GLOBAL_STATE static float gts;
+GLOBAL_STATE static float wtp;
+GLOBAL_STATE static float wtr;
+GLOBAL_STATE static float wts;
+GLOBAL_STATE static float *gmb;
+GLOBAL_STATE static float *wmb;
 
-static float gg2;
-static float cdt2;
-static float gtp2;
-static float gts2;
-static float wtp2;
-static float wtr2;
+GLOBAL_STATE static float gg2;
+GLOBAL_STATE static float cdt2;
+GLOBAL_STATE static float gtp2;
+GLOBAL_STATE static float gts2;
+GLOBAL_STATE static float wtp2;
+GLOBAL_STATE static float wtr2;
 
 /*
  * The fun bit.

--- a/bristol/hammond.c
+++ b/bristol/hammond.c
@@ -40,13 +40,13 @@
 
 #include "click.h"
 
-int clickset[128];
+GLOBAL_STATE static int clickset[128];
 
 #include "bristol.h"
 #include "hammond.h"
 
-float note_diff;
-int samplecount;
+GLOBAL_STATE static float note_diff;
+GLOBAL_STATE static int samplecount;
 
 static void fillWave(float *, int, int);
 static void buildHammondSound(bristolOP *, unsigned char);
@@ -60,25 +60,25 @@ static void fillHammondWave(bristolOP *);
  * The same is true of using single global result waves, wave[6] and wave[7].
  * These need to be moved to private address space, ie, we need more 
  * instantiation.
-static int sineform[16] = {1, 1, 1, 1, 1, 1, 1, 1, 1};
-static int wavelevel[16];
-static int waveindex[16] = {264, 23, 268, 491, 523, 708, 354, 112, 661};
-static int percussion[16] = {0, 0, 0, 0, 0, 0, 0, 0, 0};
+GLOBAL_STATE static int sineform[16] = {1, 1, 1, 1, 1, 1, 1, 1, 1};
+GLOBAL_STATE static int wavelevel[16];
+GLOBAL_STATE static int waveindex[16] = {264, 23, 268, 491, 523, 708, 354, 112, 661};
+GLOBAL_STATE static int percussion[16] = {0, 0, 0, 0, 0, 0, 0, 0, 0};
  */
-static int *sineform;
-static int *wavelevel;
-static int *waveindex;
-static int *percussion;
+GLOBAL_STATE static int *sineform;
+GLOBAL_STATE static int *wavelevel;
+GLOBAL_STATE static int *waveindex;
+GLOBAL_STATE static int *percussion;
 
-float *wave1;
-float *wave2;
+GLOBAL_STATE static float *wave1;
+GLOBAL_STATE static float *wave2;
 
 /*
  * This can be a single list, it is used to generate the different pipes.
 static int sweeps[16] = {1, 2, 3, 4, 6, 8, 10, 12, 16, 0,0,0,0,0,0,0};
 static float sweeps[16] = {1, 1.5, 2, 4, 6, 8, 10, 12, 16, 0,0,0,0,0,0,0};
  */
-static float sweeps[16] = {2, 6, 4, 8, 12, 16, 20, 24, 32, 0,0,0,0,0,0,0};
+static const float sweeps[16] = {2, 6, 4, 8, 12, 16, 20, 24, 32, 0,0,0,0,0,0,0};
 
 /*
  * The name of this operator, IO count, and IO names.

--- a/bristol/hammondchorus.c
+++ b/bristol/hammondchorus.c
@@ -40,43 +40,43 @@
 #define HCHORUS_IN_IND 0
 #define HCHORUS_OUT_IND 1
 
-int scanrate = 172;
+GLOBAL_STATE static int scanrate = 172;
 
 static void fillGainTable(float *, int);
 static void fillDrainTable(float *, int);
-float *upgain = NULL;
-float *downgain = NULL;
+GLOBAL_STATE static float *upgain = NULL;
+GLOBAL_STATE static float *downgain = NULL;
 
 /*
  * Three different taps rates for V1/V2/V3, fast and shallow to slow and deep,
  * then we mix them for chorus. They are also staggered to reduce matches and
  * there is a null (non moving) tap for some of the depths.
-int atap[32]= {0,0,1,1,2,2,3,3,4,4,5,5,6,6,7,7,8,8,7,7,6,6,5,5,4,4,3,3,2,2,1,1};
-int btap[32]= {0,1,1,2,2,3,3,4,4,5,5,6,6,7,7,8,8,7,7,6,6,5,5,4,4,3,3,2,2,1,1,0};
+GLOBAL_STATE static int atap[32]= {0,0,1,1,2,2,3,3,4,4,5,5,6,6,7,7,8,8,7,7,6,6,5,5,4,4,3,3,2,2,1,1};
+GLOBAL_STATE static int btap[32]= {0,1,1,2,2,3,3,4,4,5,5,6,6,7,7,8,8,7,7,6,6,5,5,4,4,3,3,2,2,1,1,0};
  */
-int atap[32]= {0,1,2,3,4,5,6,7,8,7,6,5,4,3,2,1,0,1,2,3,4,5,6,7,8,7,6,5,4,3,2,1};
-int btap[32]= {1,2,3,4,5,6,7,8,7,6,5,4,3,2,1,0,1,2,3,4,5,6,7,8,7,6,5,4,3,2,1,0};
+GLOBAL_STATE static int atap[32]= {0,1,2,3,4,5,6,7,8,7,6,5,4,3,2,1,0,1,2,3,4,5,6,7,8,7,6,5,4,3,2,1};
+GLOBAL_STATE static int btap[32]= {1,2,3,4,5,6,7,8,7,6,5,4,3,2,1,0,1,2,3,4,5,6,7,8,7,6,5,4,3,2,1,0};
 
-int ctap[32]= {3,3,2,2,1,1,0,0,1,1,2,2,3,3,4,4,3,3,2,2,1,1,0,0,1,1,2,2,3,3,4,4};
-int dtap[32]= {3,2,2,1,1,0,0,1,1,2,2,3,3,4,4,3,3,2,2,1,1,0,0,1,1,2,2,3,3,4,4,3};
+GLOBAL_STATE static int ctap[32]= {3,3,2,2,1,1,0,0,1,1,2,2,3,3,4,4,3,3,2,2,1,1,0,0,1,1,2,2,3,3,4,4};
+GLOBAL_STATE static int dtap[32]= {3,2,2,1,1,0,0,1,1,2,2,3,3,4,4,3,3,2,2,1,1,0,0,1,1,2,2,3,3,4,4,3};
 
-int etap[32]= {4,4,5,5,6,6,7,7,8,8,7,7,6,6,5,5,4,4,5,5,6,6,7,7,8,8,7,7,6,6,5,5};
-int ftap[32]= {4,5,5,6,6,7,7,8,8,7,7,6,6,5,5,4,4,5,5,6,6,7,7,8,8,7,7,6,6,5,5,4};
+GLOBAL_STATE static int etap[32]= {4,4,5,5,6,6,7,7,8,8,7,7,6,6,5,5,4,4,5,5,6,6,7,7,8,8,7,7,6,6,5,5};
+GLOBAL_STATE static int ftap[32]= {4,5,5,6,6,7,7,8,8,7,7,6,6,5,5,4,4,5,5,6,6,7,7,8,8,7,7,6,6,5,5,4};
 
-int ztap[32]= {7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7};
+GLOBAL_STATE static int ztap[32]= {7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7};
 
-//int *tap1, *tap2, *tap3, *tap4, *tap5, *tap6;
-int *tap1 = NULL, *tap2 = NULL, *tap3 = NULL;
-int *tap4 = NULL, *tap5 = NULL, *tap6 = NULL;
+//GLOBAL_STATE static int *tap1, *tap2, *tap3, *tap4, *tap5, *tap6;
+GLOBAL_STATE static int *tap1 = NULL, *tap2 = NULL, *tap3 = NULL;
+GLOBAL_STATE static int *tap4 = NULL, *tap5 = NULL, *tap6 = NULL;
 
-//float tapgain[TAPS] = {1.5, 2, 2.5, 3.0, 3.5, 4, 4.5, 5, 5.5};
+//GLOBAL_STATE static float tapgain[TAPS] = {1.5, 2, 2.5, 3.0, 3.5, 4, 4.5, 5, 5.5};
 /* As the filtering goes up the signal gain goes down, so a small correction */
-//float tapgain[TAPS] = {1.0, 1.03, 1.06, 1.09, 1.12, 1.15, 1.18, 1.21, 1.24};
-float tapgain[TAPS] = {1.0, 1.01, 1.02, 1.03, 1.04, 1.05, 1.06, 1.07, 1.08};
+//GLOBAL_STATE static float tapgain[TAPS] = {1.0, 1.03, 1.06, 1.09, 1.12, 1.15, 1.18, 1.21, 1.24};
+GLOBAL_STATE static float tapgain[TAPS] = {1.0, 1.01, 1.02, 1.03, 1.04, 1.05, 1.06, 1.07, 1.08};
 
-/* float tapfilt[TAPS] = {0.95, 0.9, 0.85, 0.8, 0.75, 0.7, 0.65, 0.6, 0.55}; */
+/* GLOBAL_STATE static float tapfilt[TAPS] = {0.95, 0.9, 0.85, 0.8, 0.75, 0.7, 0.65, 0.6, 0.55}; */
 /* These get reset anyway, the are a cummulative multiplication */
-float tapfilt[TAPS] = {0.99, 0.98, 0.97, 0.96, 0.95, 0.94, 0.93, 0.92, 0.91};
+GLOBAL_STATE static float tapfilt[TAPS] = {0.99, 0.98, 0.97, 0.96, 0.95, 0.94, 0.93, 0.92, 0.91};
 
 /*
  * Reset any local memory information.
@@ -93,7 +93,7 @@ static int destroy(bristolOP *operator)
 	return(0);
 }
 
-static int reDelay = 0;
+GLOBAL_STATE static int reDelay = 0;
 
 /*
  * This is called by the frontend when a parameter is changed.

--- a/bristol/junodco.c
+++ b/bristol/junodco.c
@@ -39,7 +39,7 @@
 #include "bristolblo.h"
 #include "junodco.h"
 
-float note_diff;
+GLOBAL_STATE static float note_diff;
 
 #define BRISTOL_SQR 8
 

--- a/bristol/lfo.c
+++ b/bristol/lfo.c
@@ -38,7 +38,7 @@
 #include "bristol.h"
 #include "lfo.h"
 
-float note_diff;
+GLOBAL_STATE static float note_diff;
 
 /*
  * The name of this operator, IO count, and IO names.
@@ -59,7 +59,7 @@ float note_diff;
 #define LFO_WAVE_COUNT 6
 
 static void fillWave();
-static float *bitbucket = NULL;
+GLOBAL_STATE static float *bitbucket = NULL;
 
 /*
  * Reset any local memory information.

--- a/bristol/midinote.c
+++ b/bristol/midinote.c
@@ -25,7 +25,7 @@
 #include <math.h>
 #include "bristol.h"
 
-extern bristolMidiHandler bristolMidiRoutines;
+GLOBAL_STATE extern bristolMidiHandler bristolMidiRoutines;
 
 int rbMidiNoteOn(audioMain *, bristolMidiMsg *);
 int rbMidiNoteOff(audioMain *, bristolMidiMsg *);
@@ -466,9 +466,9 @@ msg->offset = 101;
 	return(0);
 }
 
-static int arbitrary = 0x12365302;
-static int nx1 = 0x67452301;
-static int nx2 = 0xefcdab89;
+GLOBAL_STATE static int arbitrary = 0x12365302;
+GLOBAL_STATE static int nx1 = 0x67452301;
+GLOBAL_STATE static int nx2 = 0xefcdab89;
 
 /*
  * Find a free voice, or take one off the current playlist.

--- a/bristol/midithread.c
+++ b/bristol/midithread.c
@@ -25,23 +25,23 @@
 #ifdef BRISTOL_SEM_OPEN
 #include <fcntl.h>
 #include <sys/stat.h>
-static char sem_long_name[32];
-static char sem_short_name[32];
+GLOBAL_STATE static char sem_long_name[32];
+GLOBAL_STATE static char sem_short_name[32];
 #endif
 #endif /* BRISTOL_SEMAPHORE */
 #include <pthread.h>
 #include "bristolmidi.h"
 #include "bristol.h"
 
-extern int midiExitReq;
+GLOBAL_STATE extern int midiExitReq;
 
 extern int midiCheck();
 extern void initMidiRoutines();
 extern void checkcallbacks(bristolMidiMsg *);
 
-extern audioMain audiomain;
+GLOBAL_STATE extern audioMain audiomain;
 
-bristolMidiHandler bristolMidiRoutines;
+GLOBAL_STATE bristolMidiHandler bristolMidiRoutines;
 void printMidiMsg(bristolMidiMsg *);
 
 void
@@ -208,8 +208,8 @@ midiMsgHandler(bristolMidiMsg *msg, audioMain *audiomain)
 	return(0);
 }
 
-extern int exitReq;
-static char *bSMD = "128.1";
+GLOBAL_STATE extern int exitReq;
+static const char *bSMD = "128.1";
 
 void *
 midiThread(audioMain *audiomain)

--- a/bristol/nro.c
+++ b/bristol/nro.c
@@ -95,10 +95,10 @@
 
 #define EMULATION 15
 
-static float note_diff;
+GLOBAL_STATE static float note_diff;
 
 /* Detuning for the different tendencies, controlled by DETUNE */
-static float dt[TENDENCY_COUNT] = {
+static const float dt[TENDENCY_COUNT] = {
  0.043,
  0.073,
  0.029,

--- a/bristol/prophetdco.c
+++ b/bristol/prophetdco.c
@@ -47,7 +47,7 @@
 #include "bristolblo.h"
 #include "prophetdco.h"
 
-float note_diff;
+GLOBAL_STATE static float note_diff;
 
 #define BRISTOL_SQR 4
 
@@ -73,7 +73,7 @@ static void buildProphetWave(float *, float , float *, float , float *, float , 
  * We should not be doing this however I need a quick resolution to some issues
  * with sync of square waves and this is a scratch buffer for the edge detector
  */
-static float *sbuf = NULL;
+GLOBAL_STATE static float *sbuf = NULL;
 
 /*
  * Reset any local memory information.

--- a/bristol/rotary.c
+++ b/bristol/rotary.c
@@ -83,8 +83,8 @@ some other parameter that I need to alter?
 
 static void newValvify(float *, int, float);
 #define ROOT2 1.4142135623730950488
-static float pidsr;
-static int stopped = 0;
+GLOBAL_STATE static float pidsr;
+GLOBAL_STATE static int stopped = 0;
 
 /*
  * Reset any local memory information.
@@ -566,7 +566,7 @@ iSnewValvify(register float *busData, register int count, register float valve)
 	}
 }
 
-static float lpf = 0; // need to bury in a local structure
+GLOBAL_STATE static float lpf = 0; // need to bury in a local structure
 
 static void
 newValvify(register float *busData, register int count, register float valve)

--- a/bristol/sdco.c
+++ b/bristol/sdco.c
@@ -41,7 +41,7 @@
 #include "bristol.h"
 #include "sdco.h"
 
-float note_diff;
+GLOBAL_STATE static float note_diff;
 
 /*
  * The name of this operator, IO count, and IO names.

--- a/bristol/soundManager.c
+++ b/bristol/soundManager.c
@@ -21,7 +21,7 @@
 #include <stdlib.h>
 #include "bristol.h"
 
-extern audioMain audiomain;
+GLOBAL_STATE extern audioMain audiomain;
 extern void midithreadexit();
 
 bristolSound *

--- a/bristol/thesermon.c
+++ b/bristol/thesermon.c
@@ -132,12 +132,12 @@ static void filltriwave(float *, int, double, int);
  * bright and normal settings but these are not really concerned with those
  * settings. FFS.
  */
-typedef struct Crosstalk {
+GLOBAL_STATE typedef struct Crosstalk {
 	int wheel;
 	float gain;
 } crosstalk;
 
-typedef struct Tonewheels {
+GLOBAL_STATE typedef struct Tonewheels {
 	float freq; /* Hz */
 	float step; /* wavetable index step required to generate this frequency */
 	float flutter;
@@ -150,13 +150,13 @@ typedef struct Tonewheels {
 	/* There are more, we could bury the wavetables and buffers in here. */
 } tonewheels;
 
-tonewheels gearbox[92];
+GLOBAL_STATE tonewheels gearbox[92];
 
 /* Bright should be burried in the tonewheel structure */
-static int bright, btnote, btdelay = 0, samplerate;
+GLOBAL_STATE static int bright, btnote, btdelay = 0, samplerate;
 
 #ifdef TONEMATRIX
-struct {
+GLOBAL_STATE struct {
 	float gain;
 	int percussive;
 	float numerator;

--- a/bristol/trilogyosc.c
+++ b/bristol/trilogyosc.c
@@ -40,12 +40,12 @@
 #include "bristolblo.h"
 #include "trilogyosc.h"
 
-float note_diff;
-int samplecount;
+GLOBAL_STATE static float note_diff;
+GLOBAL_STATE static int samplecount;
 
 static void fillWave(float *, int, int);
 static void buildTrilogySound(bristolOP *, bristolOPParams *);
-static float *zerobuf;
+GLOBAL_STATE static float *zerobuf;
 
 /*
  * Use of these mean that we can only product a single trilogyosc oscillator.
@@ -62,7 +62,7 @@ static float *zerobuf;
  *
  * We have 16, 8, 4, 2.
  */
-static float sweeps[16] = {2, 4, 8, 16, 1, 32, 12, 20, 24, 32, 0,0,0,0,0,0};
+static const float sweeps[16] = {2, 4, 8, 16, 1, 32, 12, 20, 24, 32, 0,0,0,0,0,0};
 
 /*
  * The name of this operator, IO count, and IO names.

--- a/bristol/vibrachorus.c
+++ b/bristol/vibrachorus.c
@@ -99,7 +99,7 @@ static int reset(bristolOP *operator, bristolOPParams *param)
 	return(0);
 }
 
-static float table[TABSIZE];
+GLOBAL_STATE static float table[TABSIZE];
 
 /*
  * Vibrachorus will take a signal and give it vibra. Depending on the gain the

--- a/bristol/vox.c
+++ b/bristol/vox.c
@@ -40,8 +40,8 @@
 #include "bristolblo.h"
 #include "vox.h"
 
-float note_diff;
-int samplecount;
+GLOBAL_STATE static float note_diff;
+GLOBAL_STATE static int samplecount;
 
 static void fillWave(float *, int, int);
 static void buildVoxSound(bristolOP *, bristolOPParams *, unsigned char);
@@ -57,10 +57,10 @@ static void fillVoxM2Wave(bristolOP *, bristolOPParams *);
  * These need to be moved to private address space, ie, we need more 
  * instantiation.
  */
-static int *wavelevel;
+GLOBAL_STATE static int *wavelevel;
 
-float *wave1;
-float *wave2;
+GLOBAL_STATE static float *wave1;
+GLOBAL_STATE static float *wave2;
 
 /*
  * This can be a single list, it is used to generate the different pipes.
@@ -69,7 +69,7 @@ float *wave2;
 {16', 8', 4', 5-1/3', 2-2/3', 2', 1-1/3', 1-1/5', 1', 0,0,0,0,0,0,0};
 { 2,  4,  8,      6,     12, 16,     20,     24, 32, 0,0,0,0,0,0,0};
  */
-static float sweeps[16] = {2, 4, 8, 6, 12, 16, 20, 24, 32, 0,0,0,0,0,0,0};
+static const float sweeps[16] = {2, 4, 8, 6, 12, 16, 20, 24, 32, 0,0,0,0,0,0,0};
 
 /*
  * The name of this operator, IO count, and IO names.

--- a/configure
+++ b/configure
@@ -12122,9 +12122,9 @@ fi
 if test "x$TRY_VC" = 'xyes'
 then
 	which startBristol > /dev/null 2>&1
-	if test $? == 0; then showErrMsg1; fi
+	if test $? = 0; then showErrMsg1; fi
 	which bristol > /dev/null 2>&1
-	if test $? == 0; then showErrMsg1; fi
+	if test $? = 0; then showErrMsg1; fi
 	if test -f ${prefix}/bin/bristol; then showErrMsg1; fi
 fi
 
@@ -12307,7 +12307,7 @@ else
   USE_EXP_ATTACK=no
 fi
 
-if test "x$USE_EXP_ATTACK" == "xyes"
+if test "x$USE_EXP_ATTACK" = "xyes"
 then
 	BRISTOL_LIN_ATTACK=
 fi
@@ -12322,7 +12322,7 @@ else
   USE_SEMAPHORE=no
 fi
 
-if test "x$USE_SEMAPHORE" == "xyes"
+if test "x$USE_SEMAPHORE" = "xyes"
 then
 	BRISTOL_SEMAPHORE=-DBRISTOL_SEMAPHORE
 
@@ -12350,7 +12350,7 @@ else
   USE_BARRIER=no
 fi
 
-if test "x$USE_BARRIER" == "xyes"
+if test "x$USE_BARRIER" = "xyes"
 then
 	BRISTOL_BARRIER=-DUSE_MLOCK
 fi
@@ -15468,7 +15468,7 @@ echo \| Build with sem_open ............................ : true
 fi
 fi
 
-if test $USE_BARRIER == "yes"; then
+if test $USE_BARRIER = "yes"; then
 echo \| Build with jrb memory barrier .................. : true
 fi
 
@@ -15495,7 +15495,7 @@ echo \| Default voicecount ............................. : BRISTOL_VOICECOUNT=$_
 if test $BRR != 10; then
 echo \| Envelope max ramp time ......................... : $BRR seconds
 fi
-if test x$USE_EXP_ATTACK == "xyes"; then
+if test x$USE_EXP_ATTACK = "xyes"; then
 echo \| Envelope attack type ........................... : exponential
 fi
 echo \| author ......................................... : Nick Copeland

--- a/configure
+++ b/configure
@@ -12205,6 +12205,9 @@ else
 fi
 
 
+# NOTE(jpc) a marker for global variables, so I can rework this later
+CFLAGS="$CFLAGS -DGLOBAL_STATE="
+CPPFLAGS="$CPPFLAGS -DGLOBAL_STATE="
 
 # Checks for typedefs, structures, and compiler characteristics.
 

--- a/configure.ac
+++ b/configure.ac
@@ -62,9 +62,9 @@ AC_ARG_ENABLE(version_check, [  --disable-version-check	ignore preinstalled vers
 if test "x$TRY_VC" = 'xyes'
 then
 	which startBristol > /dev/null 2>&1
-	if test $? == 0; then showErrMsg1; fi
+	if test $? = 0; then showErrMsg1; fi
 	which bristol > /dev/null 2>&1
-	if test $? == 0; then showErrMsg1; fi
+	if test $? = 0; then showErrMsg1; fi
 	if test -f ${prefix}/bin/bristol; then showErrMsg1; fi
 fi
 
@@ -166,7 +166,7 @@ AC_SUBST(_BRISTOL_VOICES)
 
 BRISTOL_LIN_ATTACK=-DBRISTOL_LIN_ATTACK
 AC_ARG_ENABLE(exp-attack, [  --enable-exp-attack		enable exponential attack], USE_EXP_ATTACK=yes , USE_EXP_ATTACK=no )
-if test "x$USE_EXP_ATTACK" == "xyes"
+if test "x$USE_EXP_ATTACK" = "xyes"
 then
 	BRISTOL_LIN_ATTACK=
 fi
@@ -176,7 +176,7 @@ BRISTOL_SEM_OPEN=
 BRISTOL_SEMAPHORE=
 AC_ARG_ENABLE(semaphore, [  --enable-semaphore		enable engine semaphores ],
 			USE_SEMAPHORE=yes , USE_SEMAPHORE=no )
-if test "x$USE_SEMAPHORE" == "xyes"
+if test "x$USE_SEMAPHORE" = "xyes"
 then
 	BRISTOL_SEMAPHORE=-DBRISTOL_SEMAPHORE
 
@@ -194,7 +194,7 @@ AC_SUBST(BRISTOL_SEMAPHORE)
 BRISTOL_BARRIER=
 AC_ARG_ENABLE(memory-barrier, [  --enable-memory-barrier	enable ringbuffer barrier],
 			USE_BARRIER=yes , USE_BARRIER=no )
-if test "x$USE_BARRIER" == "xyes"
+if test "x$USE_BARRIER" = "xyes"
 then
 	BRISTOL_BARRIER=-DUSE_MLOCK
 fi
@@ -427,7 +427,7 @@ echo \| Build with sem_open ............................ : true
 fi
 fi
 
-if test $USE_BARRIER == "yes"; then
+if test $USE_BARRIER = "yes"; then
 echo \| Build with jrb memory barrier .................. : true
 fi
 
@@ -454,7 +454,7 @@ echo \| Default voicecount ............................. : BRISTOL_VOICECOUNT=$_
 if test $BRR != 10; then
 echo \| Envelope max ramp time ......................... : $BRR seconds
 fi
-if test x$USE_EXP_ATTACK == "xyes"; then
+if test x$USE_EXP_ATTACK = "xyes"; then
 echo \| Envelope attack type ........................... : exponential
 fi
 echo \| author ......................................... : Nick Copeland

--- a/configure.ac
+++ b/configure.ac
@@ -99,6 +99,10 @@ AC_CHECK_HEADER(X11/Xutil.h, [], [HAVE_XHEADERS=false])
 AC_CHECK_HEADER(X11/Xos.h, [], [HAVE_XHEADERS=false])
 AC_CHECK_HEADER(X11/Xatom.h, [], [HAVE_XHEADERS=false])
 
+# NOTE(jpc) a marker for global variables, so I can rework this later
+CFLAGS="$CFLAGS -DGLOBAL_STATE="
+CPPFLAGS="$CPPFLAGS -DGLOBAL_STATE="
+
 # Checks for typedefs, structures, and compiler characteristics.
 
 # Checks for X11 library functions.

--- a/include/bristol/bristolblo.h
+++ b/include/bristol/bristolblo.h
@@ -39,7 +39,7 @@
 #define BLO_COSINE	6
 #define BLO_PULSE	7
 
-extern struct bristolBLO {
+struct bristolBLO {
 	int flags;
 	int harmonics;
 	int cutin;
@@ -47,14 +47,16 @@ extern struct bristolBLO {
 	int min;
 	float fraction;
 	float samplerate;
-} blo;
+};
 
-extern float blosine[BRISTOL_BLO_SIZE];
-extern float blosquare[BRISTOL_BLO_SIZE];
-extern float bloramp[BRISTOL_BLO_SIZE];
-extern float blosaw[BRISTOL_BLO_SIZE];
-extern float blotriangle[BRISTOL_BLO_SIZE];
-extern float blopulse[BRISTOL_BLO_SIZE];
+GLOBAL_STATE extern struct bristolBLO blo;
+
+GLOBAL_STATE extern float blosine[BRISTOL_BLO_SIZE];
+GLOBAL_STATE extern float blosquare[BRISTOL_BLO_SIZE];
+GLOBAL_STATE extern float bloramp[BRISTOL_BLO_SIZE];
+GLOBAL_STATE extern float blosaw[BRISTOL_BLO_SIZE];
+GLOBAL_STATE extern float blotriangle[BRISTOL_BLO_SIZE];
+GLOBAL_STATE extern float blopulse[BRISTOL_BLO_SIZE];
 
 extern void generateBLOwaveforms(int, float, int, float, int, float, int);
 extern void generateBLOwaveform(int, float *, float, int);

--- a/include/bristol/bristolblo.h
+++ b/include/bristol/bristolblo.h
@@ -39,7 +39,7 @@
 #define BLO_COSINE	6
 #define BLO_PULSE	7
 
-struct {
+extern struct bristolBLO {
 	int flags;
 	int harmonics;
 	int cutin;

--- a/include/bristol/bristolsid.h
+++ b/include/bristol/bristolsid.h
@@ -172,7 +172,7 @@
  */
 #define B_S_F_SCALER 0.000488520
 
-extern unsigned short freqmap[128];
+extern const unsigned short freqmap[128];
 
 /*
  * Finally, these are the two single access methods to the chip emulation, one

--- a/libbristolic/sid.c
+++ b/libbristolic/sid.c
@@ -148,7 +148,7 @@ extern void bristolfree();
  * varied by time since the attack was linear and the decay was somewhat
  * arbitrarily exponential which needs to be studied.
  */
-static float bSidEnvRates[16] = {
+static const float bSidEnvRates[16] = {
 	0.002,
 	0.006,
 	0.016,
@@ -171,7 +171,7 @@ static float bSidEnvRates[16] = {
  * The following table is actually based on a 2MHz divider circuit, it is not
  * actually equally tempered.
  */
-unsigned short freqmap[128] = {
+const unsigned short freqmap[128] = {
 	(unsigned short) (8.175879 / B_SID_FREQ_DIV),
 	(unsigned short) (8.661983 / B_SID_FREQ_DIV),
 	(unsigned short) (9.177091 / B_SID_FREQ_DIV),
@@ -449,7 +449,7 @@ static unsigned char bSidGet(int, unsigned char, unsigned char);
 /*
  * Default dispatch table, this mostly gets overwritten on RESET
  */
-bSidRoutine bSidDispatch[B_SID_REGISTERS] = {
+GLOBAL_STATE static bSidRoutine bSidDispatch[B_SID_REGISTERS] = {
 	bSidGet,
 	bSidGet,
 	bSidGet,
@@ -512,7 +512,7 @@ bSidIORoutine bSidIODispatch[B_SID_IO] = {
 /*
  * Up to B_SID_COUNT chips can be emulated on request
  */
-bSid *SID[B_SID_COUNT];
+GLOBAL_STATE static bSid *SID[B_SID_COUNT];
 
 static unsigned char
 bSidGet(int id, unsigned char comm, unsigned char param)


### PR DESCRIPTION
This PR contains fixes to a variety of problems.

First off, building on a current Linux system, there are many linking errors of the type "multiple definitions".
As one example, the variable `float note_diff` is defined in multiple sources, without the static keyword, although the use of this variable is file-local.

I went through the global variables and applied the fixes as I found appropriate.

Moreover, I've tagged global variables with a tag `GLOBAL_STATE`, if this is OK.
It's in order to help future efforts of porting Bristol to plugins, where the global state is a problem and it must be eventually rewritten in a more appropriate manner.

Also, `const` keywords where possible, fixes of bash errors, etc.